### PR TITLE
Fix GLiNER image provisioning and e2e cleanup deploy races

### DIFF
--- a/libs/cli/cogniverse_cli/images.py
+++ b/libs/cli/cogniverse_cli/images.py
@@ -22,6 +22,10 @@ DASHBOARD_TAGS_BY_BACKEND = {
     "cuda": "cogniverse/dashboard-cuda:dev",
     "rocm": "cogniverse/dashboard-rocm:dev",
 }
+# GLiNER sidecar — backend-agnostic CPU-only NER server (deploy/gliner). Its
+# chart image uses pullPolicy: Never, so k3d must have it built+imported or
+# the pod ErrImageNeverPulls on a fresh deploy. One image, all backends.
+GLINER_TAG = "cogniverse/gliner:dev"
 # colpali, whisper, and the LateOn/DenseOn text embedders are no longer
 # built by us — vLLM serves them all:
 # TomoroAI/tomoro-colqwen3-embed-4b via inference.vllm_colpali (vllm/vllm-openai-cpu)
@@ -94,9 +98,10 @@ def build_images(
     """Build all cogniverse-owned Docker images.
 
     Builds the runtime + dashboard variants matching ``torch_backend``
-    (auto-detected via ``detect_torch_backend()`` when None). ColPali,
-    Whisper, and the LateOn/DenseOn text embedders are now served via
-    vLLM (vllm/vllm-openai-cpu) and pulled directly by k3d.
+    (auto-detected via ``detect_torch_backend()`` when None) plus the
+    backend-agnostic GLiNER sidecar. ColPali, Whisper, and the
+    LateOn/DenseOn text embedders are served via vLLM
+    (vllm/vllm-openai-cpu) and pulled directly by k3d.
     """
     backend = torch_backend or detect_torch_backend()
     runtime_tag = RUNTIME_TAGS_BY_BACKEND[backend]
@@ -106,6 +111,8 @@ def build_images(
     workspace_builds = [
         (runtime_tag, "libs/runtime/Dockerfile", ".", backend_arg),
         (dashboard_tag, "libs/dashboard/Dockerfile", ".", backend_arg),
+        # GLiNER takes no TORCH_BACKEND arg and builds from its own context.
+        (GLINER_TAG, "deploy/gliner/Dockerfile", "deploy/gliner", []),
     ]
     built: list[str] = []
     for tag, dockerfile, context, extra_args in workspace_builds:

--- a/tests/cli/unit/test_images.py
+++ b/tests/cli/unit/test_images.py
@@ -29,10 +29,10 @@ class TestBuildImages:
     @patch("cogniverse_cli.images.subprocess.run")
     def test_build_images_calls_docker_build(self, mock_run: object) -> None:
         """One docker build per cogniverse-owned image: backend-specific
-        runtime + dashboard (TORCH_BACKEND build-arg). ColPali, Whisper, and
-        the LateOn/DenseOn text embedders are now served by vLLM
-        (vllm/vllm-openai-cpu) and pulled directly by k3d, so no local build
-        is needed for them."""
+        runtime + dashboard (TORCH_BACKEND build-arg) plus the backend-agnostic
+        GLiNER sidecar. ColPali, Whisper, and the LateOn/DenseOn text embedders
+        are now served by vLLM (vllm/vllm-openai-cpu) and pulled directly by
+        k3d, so no local build is needed for them."""
         mock_run.return_value = subprocess.CompletedProcess(  # type: ignore[attr-defined]
             args=[], returncode=0
         )
@@ -43,8 +43,9 @@ class TestBuildImages:
         assert tags == [
             "cogniverse/runtime-cpu:dev",
             "cogniverse/dashboard-cpu:dev",
+            "cogniverse/gliner:dev",
         ]
-        assert mock_run.call_count == 2  # type: ignore[attr-defined]
+        assert mock_run.call_count == 3  # type: ignore[attr-defined]
 
         for call in mock_run.call_args_list:  # type: ignore[attr-defined]
             cmd = call[0][0]
@@ -72,12 +73,11 @@ class TestBuildImages:
         assert "cogniverse/dashboard-rocm:dev" in dashboard_cmd
 
     @patch("cogniverse_cli.images.subprocess.run")
-    def test_build_images_builds_only_runtime_and_dashboard(
-        self, mock_run: object
-    ) -> None:
-        """LateOn/DenseOn are served by stock vLLM now — the retired pylate
-        sidecar image must never be built again. Only the runtime and
-        dashboard images are cogniverse-owned builds."""
+    def test_build_images_builds_gliner_not_pylate(self, mock_run: object) -> None:
+        """GLiNER (pullPolicy: Never in the chart) MUST be built+imported by
+        ``up`` or its pod ErrImageNeverPulls on a fresh deploy. The retired
+        pylate sidecar must never be built again. GLiNER takes no
+        TORCH_BACKEND arg and builds from its own ``deploy/gliner`` context."""
         mock_run.return_value = subprocess.CompletedProcess(  # type: ignore[attr-defined]
             args=[], returncode=0
         )
@@ -87,12 +87,18 @@ class TestBuildImages:
         assert built == [
             "cogniverse/runtime-cpu:dev",
             "cogniverse/dashboard-cpu:dev",
+            "cogniverse/gliner:dev",
         ]
-        assert mock_run.call_count == 2  # type: ignore[attr-defined]
+        assert mock_run.call_count == 3  # type: ignore[attr-defined]
         all_cmds = [
             call[0][0]
             for call in mock_run.call_args_list  # type: ignore[attr-defined]
         ]
+        # GLiNER is built from deploy/gliner/Dockerfile with NO TORCH_BACKEND.
+        gliner_cmd = next(c for c in all_cmds if "cogniverse/gliner:dev" in c)
+        assert "deploy/gliner/Dockerfile" in gliner_cmd
+        assert "deploy/gliner" in gliner_cmd
+        assert not any(a.startswith("TORCH_BACKEND=") for a in gliner_cmd)
         for cmd in all_cmds:
             assert "deploy/pylate/Dockerfile" not in cmd
             assert "cogniverse/pylate:dev" not in cmd

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -941,10 +941,13 @@ def _cleanup_test_tenants() -> None:
         if tid and any(tid.startswith(p) for p in _TEST_TENANT_PREFIXES):
             tenants_seen.add(tid)
 
-    # Delete concurrently with a total budget so a large backlog can't hang
-    # session setup/teardown (each delete undeploys a Vespa schema, which is
-    # slow; sequentially, hundreds of accumulated test tenants take hours).
-    # What isn't reaped this run is picked up by the next sweep.
+    # Delete serially (one worker) under a total budget. Each delete undeploys
+    # a Vespa schema, which redeploys the WHOLE application package; concurrent
+    # undeploys race on that shared package rebuild — the loser sees a stale
+    # survivor set and Vespa rejects it ("services.xml does not exist" /
+    # "schema-removal ... loss of all data"). Serial avoids the race; the
+    # budget keeps a large backlog from hanging setup/teardown, and what isn't
+    # reaped this run is picked up by the next sweep.
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
     def _delete_one(tid: str) -> None:
@@ -955,7 +958,7 @@ def _cleanup_test_tenants() -> None:
             print(f"Cleanup failed for tenant {tid}: {exc}")
 
     sweep_deadline = _t.monotonic() + 180.0
-    pool = ThreadPoolExecutor(max_workers=8)
+    pool = ThreadPoolExecutor(max_workers=1)
     try:
         futures = [pool.submit(_delete_one, tid) for tid in sorted(tenants_seen)]
         for _fut in as_completed(futures):


### PR DESCRIPTION
## Summary
Stacked on #4. Two deploy-tooling fixes surfaced during the inference-stack e2e validation:
- `build_images` now builds + imports the backend-agnostic `cogniverse/gliner:dev` (its chart image is `pullPolicy: Never`, so a fresh `up` previously left the gliner pod `ErrImageNeverPull`, breaking gateway routing + entity extraction).
- The e2e tenant-cleanup sweep now deletes serially (1 worker) instead of 8; concurrent deletes each redeploy the whole Vespa app package and raced on the shared rebuild (`services.xml`-missing / `schema-removal`).

## Test Plan
- [x] `tests/cli/unit/test_images.py` asserts gliner is built (deploy/gliner, no TORCH_BACKEND) and pylate never is; 88 CLI unit tests green.
- [x] e2e session run confirms the serial cleanup produces 0 `services.xml`/`schema-removal` races.