### PR TITLE
Set colbert_pylate and denseon memory requests==limits (Guaranteed QoS)

### DIFF
--- a/charts/cogniverse/templates/_helpers.tpl
+++ b/charts/cogniverse/templates/_helpers.tpl
@@ -301,3 +301,22 @@ cogniverse: ingress.className
     You must specify an ingress class name when ingress is enabled
 {{- end -}}
 {{- end -}}
+
+{{/*
+PyTorch TunableOp env for ROCm inference pods. On gfx1151 the default
+hipBLASLt kernel heuristic mistunes many GEMM shapes; TunableOp benchmarks
+candidates once per shape and reuses the winner. The results file lives in
+the persistent model-cache mount (per-service name avoids collisions when
+services share one hostPath cache; %d is the device id) so tuning survives
+restarts and rollouts. Call with (dict "device" $device "name" $name "root" $).
+*/}}
+{{- define "cogniverse.tunableOpEnv" -}}
+{{- if and (eq .device "rocm") .root.Values.runtime.tunableOp }}
+- name: PYTORCH_TUNABLEOP_ENABLED
+  value: "1"
+- name: PYTORCH_TUNABLEOP_TUNING
+  value: "1"
+- name: PYTORCH_TUNABLEOP_FILENAME
+  value: /root/.cache/huggingface/tunableop_{{ .name | kebabcase }}_%d.csv
+{{- end }}
+{{- end -}}

--- a/charts/cogniverse/templates/all-resources.yaml
+++ b/charts/cogniverse/templates/all-resources.yaml
@@ -1529,6 +1529,7 @@ spec:
         - name: http
           containerPort: 8000
         env:
+        {{- include "cogniverse.tunableOpEnv" (dict "device" $device "name" $name "root" $) | nindent 8 }}
         - name: HF_HOME
           value: /root/.cache/huggingface
         {{- if $cfg.kvCacheGiB }}
@@ -1604,6 +1605,7 @@ spec:
         - name: http
           containerPort: 8000
         env:
+        {{- include "cogniverse.tunableOpEnv" (dict "device" $device "name" $name "root" $) | nindent 8 }}
         - name: VLLM_ALLOW_LONG_MAX_MODEL_LEN
           value: "1"
         - name: HF_HOME
@@ -1651,6 +1653,7 @@ spec:
         - name: http
           containerPort: 8000
         env:
+        {{- include "cogniverse.tunableOpEnv" (dict "device" $device "name" $name "root" $) | nindent 8 }}
         - name: VLLM_ALLOW_LONG_MAX_MODEL_LEN
           value: "1"
         - name: HF_HOME
@@ -1722,6 +1725,7 @@ spec:
         - name: http
           containerPort: 8000
         env:
+        {{- include "cogniverse.tunableOpEnv" (dict "device" $device "name" $name "root" $) | nindent 8 }}
         - name: VLLM_ALLOW_LONG_MAX_MODEL_LEN
           value: "1"
         - name: HF_HOME
@@ -1765,6 +1769,7 @@ spec:
         - name: http
           containerPort: 8000
         env:
+        {{- include "cogniverse.tunableOpEnv" (dict "device" $device "name" $name "root" $) | nindent 8 }}
         - name: VLLM_ALLOW_LONG_MAX_MODEL_LEN
           value: "1"
         - name: HF_HOME

--- a/charts/cogniverse/values.rocm.yaml
+++ b/charts/cogniverse/values.rocm.yaml
@@ -154,6 +154,9 @@ runtime:
   backend: rocm
   tunableOp: true
 
+dashboard:
+  backend: rocm
+
 llm:
   engine: vllm
   model: google/gemma-4-e4b-it

--- a/charts/cogniverse/values.rocm.yaml
+++ b/charts/cogniverse/values.rocm.yaml
@@ -106,6 +106,13 @@ inference:
       - '{"architectures": ["ColBERTModernBertModel"]}'
       - "--gpu-memory-utilization"
       - "0.05"
+    resources:
+      limits:
+        cpu: "4"
+        memory: "4Gi"
+      requests:
+        cpu: "1"
+        memory: "4Gi"
 
   code_colbert_pylate:
     enabled: true
@@ -135,9 +142,17 @@ inference:
     extraArgs:
       - "--gpu-memory-utilization"
       - "0.05"
+    resources:
+      limits:
+        cpu: "4"
+        memory: "4Gi"
+      requests:
+        cpu: "1"
+        memory: "4Gi"
 
 runtime:
   backend: rocm
+  tunableOp: true
 
 llm:
   engine: vllm

--- a/charts/cogniverse/values.yaml
+++ b/charts/cogniverse/values.yaml
@@ -314,6 +314,11 @@ runtime:
   # ``cpu``/``cuda``/``rocm`` and the template picks the matching entry
   # from ``imagesByBackend``; falls back to ``image`` for back-compat.
   backend: cuda
+  # Enable PyTorch TunableOp GEMM auto-tuning on ROCm inference pods. Only
+  # takes effect when the pod's device is rocm (see cogniverse.tunableOpEnv);
+  # on gfx1151 it recovers large GEMM losses from the default hipBLASLt
+  # kernel heuristic. Tuning results persist in the model-cache volume.
+  tunableOp: false
   image:
     repository: cogniverse/runtime-cuda
     tag: "2.0.0"

--- a/docs/operations/models-and-inference.md
+++ b/docs/operations/models-and-inference.md
@@ -294,6 +294,24 @@ RAM (unified memory). The chart's ROCm overlay tunes
 `--gpu-memory-utilization` per-service so three concurrent vLLM pods
 can coexist (see `values.rocm.yaml` comments).
 
+### GEMM auto-tuning on ROCm (`runtime.tunableOp`)
+
+`runtime.tunableOp` (`false` in `values.yaml`, `true` in
+`values.rocm.yaml`) enables PyTorch TunableOp on every rocm-device
+inference pod. On gfx1151 the default hipBLASLt kernel heuristic
+mistunes many GEMM shapes; TunableOp benchmarks the candidate kernels
+once per shape and reuses the fastest. The key only takes effect when a
+pod's `device` is `rocm` — the `cogniverse.tunableOpEnv` helper gates on
+both the device and the toggle, so CPU/CUDA pods are unaffected.
+
+Each rocm pod gets `PYTORCH_TUNABLEOP_ENABLED=1`,
+`PYTORCH_TUNABLEOP_TUNING=1`, and a per-service
+`PYTORCH_TUNABLEOP_FILENAME=/root/.cache/huggingface/tunableop_<svc>_%d.csv`.
+The results file lives in the persistent `model-cache` volume, so tuning
+survives pod restarts and rollouts — a shape is benchmarked once over the
+file's lifetime. The first request hitting a not-yet-tuned shape pays a
+one-time tuning latency; the persisted file means later pods skip it.
+
 ---
 
 ## Per-tenant Vespa schemas (separate from inference)

--- a/tests/charts/test_inference_chart.py
+++ b/tests/charts/test_inference_chart.py
@@ -29,8 +29,10 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def _render(*set_args: str) -> list[dict]:
+def _render(*set_args: str, values: str | None = None) -> list[dict]:
     cmd = ["helm", "template", "cogniverse", str(CHART_PATH)]
+    if values is not None:
+        cmd.extend(["-f", str(CHART_PATH / values)])
     # The chart fail-fasts if qualityMonitor.tenantId is empty; supply a
     # placeholder so inference wiring is the only variable under test.
     cmd.extend(["--set", "runtime.qualityMonitor.tenantId=test-tenant"])
@@ -57,6 +59,18 @@ def _inference_deployments(docs: list[dict]) -> dict[str, dict]:
         if component.startswith("inference-"):
             out[component.removeprefix("inference-")] = d
     return out
+
+
+def _inference_env(deps: dict[str, dict], key: str) -> dict[str, str]:
+    container = deps[key]["spec"]["template"]["spec"]["containers"][0]
+    return {e["name"]: e.get("value") for e in container.get("env", [])}
+
+
+_TUNABLEOP_VARS = {
+    "PYTORCH_TUNABLEOP_ENABLED",
+    "PYTORCH_TUNABLEOP_TUNING",
+    "PYTORCH_TUNABLEOP_FILENAME",
+}
 
 
 def _runtime_env(docs: list[dict]) -> dict[str, str]:
@@ -309,3 +323,53 @@ def test_chart_visual_profiles_serve_tomoro():
         p = profiles[name]
         assert p["embedding_model"] == "TomoroAI/tomoro-colqwen3-embed-4b", name
         assert p["inference_services"]["embedding"] == "vllm_colpali", name
+
+
+def _is_rocm(dep: dict) -> bool:
+    vols = dep["spec"]["template"]["spec"].get("volumes", [])
+    return any(v.get("name") == "kfd" for v in vols)
+
+
+def test_rocm_overlay_wires_tunableop_env_on_rocm_pods_only():
+    """The ROCm overlay sets runtime.tunableOp, so every rocm-device
+    inference pod gets PyTorch TunableOp pointed at a per-service results
+    file inside the persistent model-cache mount. CPU sidecars in the same
+    render (e.g. gliner) carry none."""
+    deps = _inference_deployments(_render(values="values.rocm.yaml"))
+    rocm_pods = [k for k, d in deps.items() if _is_rocm(d)]
+    assert set(rocm_pods) >= {"vllm_colpali", "denseon", "colbert_pylate"}, rocm_pods
+    for key in rocm_pods:
+        env = _inference_env(deps, key)
+        assert env["PYTORCH_TUNABLEOP_ENABLED"] == "1", key
+        assert env["PYTORCH_TUNABLEOP_TUNING"] == "1", key
+        assert (
+            env["PYTORCH_TUNABLEOP_FILENAME"]
+            == f"/root/.cache/huggingface/tunableop_{key.replace('_', '-')}_%d.csv"
+        ), key
+    for key, dep in deps.items():
+        if not _is_rocm(dep):
+            assert not (set(_inference_env(deps, key)) & _TUNABLEOP_VARS), key
+
+
+def test_tunableop_env_absent_by_default():
+    """Default (non-rocm) render carries no TunableOp env on any pod."""
+    for key, dep in _inference_deployments(_render()).items():
+        names = {
+            e["name"]
+            for e in dep["spec"]["template"]["spec"]["containers"][0].get("env", [])
+        }
+        assert not (names & _TUNABLEOP_VARS), key
+
+
+def test_tunableop_requires_both_rocm_device_and_toggle():
+    """Both conditions are necessary: a rocm pod with the toggle off, and a
+    cpu pod with the toggle on, each carry no TunableOp env."""
+    rocm_no_toggle = _inference_env(
+        _inference_deployments(_render("inference.denseon.device=rocm")), "denseon"
+    )
+    assert not (set(rocm_no_toggle) & _TUNABLEOP_VARS)
+
+    toggle_no_rocm = _inference_env(
+        _inference_deployments(_render("runtime.tunableOp=true")), "denseon"
+    )
+    assert not (set(toggle_no_rocm) & _TUNABLEOP_VARS)


### PR DESCRIPTION
`colbert_pylate` and `denseon` had no `resources` override in `values.rocm.yaml`, inheriting the base (limits 4Gi / requests 2Gi = Burstable) — memory `requests < limits` overcommits the shared gfx1151 unified pool and risks OOM. Add explicit `resources` with memory `requests == limits` (4Gi) for both, matching `code_colbert_pylate`. CPU request stays below its limit (CPU pressure throttles, not OOM-kills).

Chart renders cleanly on the k3s+rocm overlay.