### PR TITLE
Fix structured cache corrupting keyframe images past frame 9999

### DIFF
--- a/libs/core/cogniverse_core/common/cache/backends/structured_filesystem.py
+++ b/libs/core/cogniverse_core/common/cache/backends/structured_filesystem.py
@@ -275,9 +275,7 @@ class StructuredFilesystemBackend(CacheBackend):
             file_path.parent.mkdir(parents=True, exist_ok=True)
 
             # Write data
-            if isinstance(value, bytes) and key.endswith(
-                tuple(f":frame_{i}" for i in range(10000))
-            ):
+            if isinstance(value, bytes) and file_path.suffix == ".jpg":
                 # This is image data
                 async with aiofiles.open(file_path, "wb") as f:
                     await f.write(value)

--- a/tests/core/unit/test_structured_filesystem_cleanup.py
+++ b/tests/core/unit/test_structured_filesystem_cleanup.py
@@ -71,3 +71,24 @@ async def test_no_startup_cleanup_leaves_expired_file_until_accessed(tmp_path):
     # No startup sweep — the expired file remains until its key is accessed.
     assert cache_path.exists() is True
     assert backend._needs_cleanup is False
+
+
+@pytest.mark.asyncio
+async def test_keyframe_image_round_trips_raw_for_any_frame_id(tmp_path):
+    """A keyframe image must survive the cache as raw bytes regardless of frame_id.
+
+    Regression: set() wrote raw bytes only for frame_0..9999 (range(10000)) and
+    pickled higher indices, while get() returns raw for any .jpg path — so frames
+    past ~5 min of 30fps video came back as pickled bytes and failed to decode.
+    """
+    backend = StructuredFilesystemBackend(
+        StructuredFilesystemConfig(base_path=str(tmp_path), cleanup_on_startup=False)
+    )
+    raw = b"\xff\xd8\xff\xe0opaque-image-bytes\xff\xd9"
+    for frame_id in (5000, 15000, 123456):
+        key = f"prof:video:vid123:keyframes:frame_{frame_id}"
+        assert await backend.set(key, raw) is True
+        assert await backend.get(key) == raw, f"frame_{frame_id} did not round-trip"
+        path = backend._key_to_path(key)
+        assert path.suffix == ".jpg"
+        assert path.read_bytes() == raw  # raw on disk, not a pickle envelope


### PR DESCRIPTION
**CRIT (found by the audit, in the live-path cache surface).** `StructuredFilesystemBackend.set` wrote raw image bytes only when the key ended `:frame_0`…`:frame_9999` (`range(10000)`), pickling anything higher — but `get` returns raw for any `.jpg`-suffixed path, and `_key_to_path` gives **every** `frame_*` key a `.jpg` suffix regardless of index. So for `frame_id ≥ 10000` (any video past ~5 min @30fps) `set` pickled the bytes while `get` served them as a JPEG → `cv2.imdecode` failed → the frame was silently dropped on every cache hit, including the L2(MinIO)→L1 populate path the shared tier exists to serve.

Fix: gate `set`'s raw-image branch on the same `file_path.suffix == ".jpg"` check `get` uses (also covers segment frames; no arbitrary index ceiling).

Regression test `test_keyframe_image_round_trips_raw_for_any_frame_id` exercises frame_ids 5000/15000/123456 through the real backend and asserts byte-exact round-trip + raw-on-disk. Verified it **fails on the old `range(10000)` code** (returns pickle-magic bytes) and passes on the fix.

This is the load-bearing finding from the post-merge audit of the pipeline-cache work (#6).