### PR TITLE
Re-raise HTTPException in ingestion /start instead of 500

### DIFF
--- a/libs/runtime/cogniverse_runtime/routers/ingestion.py
+++ b/libs/runtime/cogniverse_runtime/routers/ingestion.py
@@ -139,6 +139,8 @@ async def start_ingestion(
             "message": "Ingestion job started successfully",
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Ingestion start error: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/tests/runtime/unit/test_ingestion_router_tenant_check.py
+++ b/tests/runtime/unit/test_ingestion_router_tenant_check.py
@@ -120,12 +120,9 @@ class TestIngestionUploadRequiresTenant:
                 "tenant_id": "unregistered_xyz",
             },
         )
-        # The endpoint wraps the body in a generic try/except that
-        # converts unexpected errors to 500 with the detail in the body.
-        # HTTPException(404) is re-raised as 404 directly. Either way,
-        # the body must mention "not registered".
-        assert resp.status_code in (404, 500), (
-            f"unexpected status {resp.status_code}: {resp.text}"
+        assert resp.status_code == 404, (
+            f"unregistered tenant must 404 (not 500); got {resp.status_code}: "
+            f"{resp.text}"
         )
         assert "not registered" in resp.text.lower(), (
             f"expected 'not registered' in body, got: {resp.text}"


### PR DESCRIPTION
**HIGH (audit Class A).** `POST /ingestion/start` wrapped its whole body in `except Exception → HTTPException(500)`, which caught the intended `HTTPException`s it raises itself — the 404 from `assert_tenant_exists` and the 400s from `require_tenant_id` / missing video-dir — and re-raised them all as **500**. So an unregistered tenant (or a bad request) got a 500, not the 404/400 the endpoint promises.

Fix: add `except HTTPException: raise` before the catch-all so deliberate HTTP errors pass through unchanged; only genuinely-unexpected errors become 500. (The other `except Exception` sites in the file — face-pipeline degrade at 702, background-task status at 1060 — are correct and untouched.)

The existing test `test_start_with_unregistered_tenant_returns_404` asserted `status_code in (404, 500)` and locked in the bug; tightened to `== 404`. Verified it **fails on the old code** (`assert 500 == 404`) and passes on the fix.