### PR TITLE
Normalize memory timestamps for ms-vs-seconds and tz-aware reads

### DIFF
--- a/libs/core/cogniverse_core/memory/_timestamps.py
+++ b/libs/core/cogniverse_core/memory/_timestamps.py
@@ -1,0 +1,48 @@
+"""Seconds-vs-milliseconds-safe, tz-aware timestamp normalization for memory.
+
+The ingestion write path validates ms-vs-s magnitude (``ingestion_client``
+``_validate_ms_timestamp``/``_validate_s_timestamp``); the memory read and
+age-compute paths did not. So a millisecond ``created_at`` clamped ages to 0
+(never aging out), raised inside naive ``datetime.fromtimestamp`` (swallowed →
+all search results dropped), and naive ISO strings were read in local tz.
+These helpers apply the same magnitude guard and assume UTC for naive input.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+# 2100-01-01 UTC in seconds; a value larger than this is almost certainly ms.
+_MAX_S_EPOCH = 4_102_444_800
+
+
+def to_epoch_seconds(value: Any) -> Optional[int]:
+    """Normalize a ``created_at`` (epoch s/ms or ISO string) to UTC epoch seconds.
+
+    Returns ``None`` for missing or unparseable input.
+    """
+    if value is None or value == "" or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        ts = float(value)
+        if ts > _MAX_S_EPOCH:  # value is in milliseconds
+            ts /= 1000.0
+        return int(ts)
+    if isinstance(value, str):
+        try:
+            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            return None
+        if dt.tzinfo is None:  # naive → UTC, not the host's local tz
+            dt = dt.replace(tzinfo=timezone.utc)
+        return int(dt.timestamp())
+    return None
+
+
+def epoch_to_iso_utc(value: Any) -> Optional[str]:
+    """Convert an epoch (seconds or milliseconds) to a tz-aware UTC ISO string."""
+    secs = to_epoch_seconds(value)
+    if secs is None:
+        return None
+    return datetime.fromtimestamp(secs, tz=timezone.utc).isoformat()

--- a/libs/core/cogniverse_core/memory/backend_vector_store.py
+++ b/libs/core/cogniverse_core/memory/backend_vector_store.py
@@ -11,6 +11,8 @@ from typing import Any, Dict, List, Optional
 
 from mem0.vector_stores.base import VectorStoreBase
 
+from cogniverse_core.memory._timestamps import epoch_to_iso_utc, to_epoch_seconds
+
 logger = logging.getLogger(__name__)
 
 
@@ -210,17 +212,9 @@ class BackendVectorStore(VectorStoreBase):
             metadata = _extract_caller_metadata(payload)
             created_at = payload.get("created_at")
 
-            # Convert created_at to Unix timestamp
-            if isinstance(created_at, str):
-                from datetime import datetime
-
-                try:
-                    dt = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
-                    created_at = int(dt.timestamp())
-                except Exception:
-                    created_at = int(time.time())
-            elif created_at is None:
-                created_at = int(time.time())
+            # Normalize created_at to UTC epoch seconds (ms→s, naive ISO→UTC)
+            normalized = to_epoch_seconds(created_at)
+            created_at = normalized if normalized is not None else int(time.time())
 
             # Create Document object
             doc_metadata = {
@@ -230,7 +224,9 @@ class BackendVectorStore(VectorStoreBase):
             }
             # Promote subject_key to a top-level field so list() can filter on
             # it server-side (it also stays in metadata_ for round-trip reads).
-            subject_key = metadata.get("subject_key") if isinstance(metadata, dict) else None
+            subject_key = (
+                metadata.get("subject_key") if isinstance(metadata, dict) else None
+            )
             if subject_key:
                 doc_metadata["subject_key"] = subject_key
             if metadata:
@@ -328,9 +324,7 @@ class BackendVectorStore(VectorStoreBase):
                 doc = search_result.document
                 created_at = doc.metadata.get("created_at")
                 if isinstance(created_at, (int, float)):
-                    from datetime import datetime
-
-                    created_at = datetime.fromtimestamp(created_at).isoformat()
+                    created_at = epoch_to_iso_utc(created_at)
 
                 mem0_results.append(
                     BackendSearchResult(
@@ -448,9 +442,7 @@ class BackendVectorStore(VectorStoreBase):
 
             created_at = doc.metadata.get("created_at")
             if isinstance(created_at, (int, float)):
-                from datetime import datetime
-
-                created_at = datetime.fromtimestamp(created_at).isoformat()
+                created_at = epoch_to_iso_utc(created_at)
             elif created_at is not None and not isinstance(created_at, str):
                 created_at = str(created_at)
 

--- a/libs/core/cogniverse_core/memory/manager.py
+++ b/libs/core/cogniverse_core/memory/manager.py
@@ -21,6 +21,7 @@ os.environ["MEM0_TELEMETRY"] = "False"
 from mem0 import Memory
 
 from cogniverse_core.common.tenant_utils import SYSTEM_TENANT_ID
+from cogniverse_core.memory._timestamps import to_epoch_seconds
 from cogniverse_foundation.caching import TenantLRUCache
 
 logger = logging.getLogger(__name__)
@@ -1308,20 +1309,8 @@ class Mem0MemoryManager:
 
     @staticmethod
     def _compute_age_seconds(memory: Dict[str, Any], now_epoch: int) -> Optional[int]:
-        created_at = memory.get("created_at")
-        if not created_at:
-            return None
-        if isinstance(created_at, str):
-            from datetime import datetime as _dt
-
-            try:
-                dt = _dt.fromisoformat(created_at.replace("Z", "+00:00"))
-                created_epoch = int(dt.timestamp())
-            except (ValueError, TypeError):
-                return None
-        elif isinstance(created_at, (int, float)):
-            created_epoch = int(created_at)
-        else:
+        created_epoch = to_epoch_seconds(memory.get("created_at"))
+        if created_epoch is None:
             return None
         return max(0, now_epoch - created_epoch)
 

--- a/tests/core/unit/test_memory_timestamps.py
+++ b/tests/core/unit/test_memory_timestamps.py
@@ -1,0 +1,58 @@
+"""Memory timestamp normalization — ms-vs-seconds magnitude + tz-aware parsing.
+
+Regressions these pin (audit Class D):
+  * a millisecond ``created_at`` made ``_compute_age_seconds`` clamp to 0 (the
+    memory never aged out) and raised inside ``datetime.fromtimestamp`` on the
+    read path (swallowed → ``search`` returned []);
+  * a naive ISO ``created_at`` was read in the host's local tz, not UTC.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from cogniverse_core.memory._timestamps import epoch_to_iso_utc, to_epoch_seconds
+
+_S = 1_700_000_000  # 2023-11-14T22:13:20 UTC, in seconds
+_MS = 1_700_000_000_000  # same instant, in milliseconds
+
+
+def test_to_epoch_seconds_milliseconds_collapse_to_seconds():
+    assert to_epoch_seconds(_MS) == _S
+    assert to_epoch_seconds(_S) == _S
+
+
+def test_to_epoch_seconds_naive_iso_is_utc_not_local():
+    expected = int(datetime(2023, 11, 15, 3, 43, 20, tzinfo=timezone.utc).timestamp())
+    assert to_epoch_seconds("2023-11-15T03:43:20") == expected
+    assert to_epoch_seconds("2023-11-15T03:43:20Z") == expected
+
+
+def test_to_epoch_seconds_aware_iso_respects_offset():
+    tz = timezone(timedelta(hours=5, minutes=30))
+    expected = int(datetime(2023, 11, 15, 3, 43, 20, tzinfo=tz).timestamp())
+    assert to_epoch_seconds("2023-11-15T03:43:20+05:30") == expected
+
+
+def test_to_epoch_seconds_rejects_missing_and_garbage():
+    assert to_epoch_seconds(None) is None
+    assert to_epoch_seconds("") is None
+    assert to_epoch_seconds(True) is None
+    assert to_epoch_seconds("not-a-date") is None
+
+
+def test_epoch_to_iso_utc_handles_milliseconds_without_raising():
+    # datetime.fromtimestamp(_MS) raises ValueError (year out of range) — the
+    # old read path swallowed that and dropped the whole search result.
+    assert epoch_to_iso_utc(_MS) == "2023-11-14T22:13:20+00:00"
+    assert epoch_to_iso_utc(_S).endswith("+00:00")
+
+
+def test_compute_age_seconds_normalizes_milliseconds():
+    from cogniverse_core.memory.manager import Mem0MemoryManager
+
+    now = _S + 100
+    # ms created_at must yield a real positive age (was clamped to 0).
+    assert Mem0MemoryManager._compute_age_seconds({"created_at": _MS}, now) == 100
+    assert Mem0MemoryManager._compute_age_seconds({"created_at": _S}, now) == 100
+    assert Mem0MemoryManager._compute_age_seconds({"created_at": None}, now) is None


### PR DESCRIPTION
**2 HIGH (audit Class D), one shared root.** The ingestion write path validates ms-vs-seconds magnitude (`_validate_ms_timestamp`/`_validate_s_timestamp`), but the memory read/age paths did not:

- `manager.py` `_compute_age_seconds`: a **millisecond** `created_at` → `now − ms` is hugely negative → `max(0,…)` clamps the age to **0**, so the memory **never ages out** (lifecycle/archival skips it forever).
- `backend_vector_store.py` `search`/`get`: `datetime.fromtimestamp(created_at)` is **naive local-tz** (IST drift on this host → wrong `.isoformat()`), and a **ms** epoch raises `ValueError: year out of range` that the surrounding `except` swallows → `search` silently returns **`[]`** (drops every result).
- Write path's naive ISO `.timestamp()` read strings in local tz, not UTC.

Fix: add `memory/_timestamps.py` with `to_epoch_seconds` (ms→s by magnitude, naive ISO→UTC) and `epoch_to_iso_utc` (tz-aware, ms-safe), mirroring the write-side magnitude guard; wire `_compute_age_seconds`, both read sites, and the write site to it.

`tests/core/unit/test_memory_timestamps.py` asserts exact values (ms collapse, naive-ISO==UTC, +05:30 offset respected, ms-ISO no-raise, ms age == 100 not 0). Verified the age test **fails on the old code** (`assert 0 == 100`). 28 existing memory unit tests still pass.