### PR TITLE
Assert ConfigScope in tenant instructions router tests

### DIFF
--- a/tests/runtime/unit/test_tenant_router.py
+++ b/tests/runtime/unit/test_tenant_router.py
@@ -14,6 +14,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from cogniverse_runtime.routers import tenant
+from cogniverse_sdk.interfaces.config_store import ConfigScope
 
 
 @pytest.fixture(autouse=True)
@@ -85,6 +86,7 @@ class TestSetInstructions:
         assert call_kwargs["service"] == "tenant_instructions"
         assert call_kwargs["config_key"] == "system_prompt"
         assert call_kwargs["config_value"]["text"] == "Always respond in bullet points."
+        assert call_kwargs["scope"] == ConfigScope.SYSTEM
 
     def test_returns_text_and_updated_at(self, tenant_client):
         client, _ = tenant_client
@@ -158,6 +160,7 @@ class TestDeleteInstructions:
         cm.set_config_value.assert_called_once()
         call_kwargs = cm.set_config_value.call_args.kwargs
         assert call_kwargs["config_value"]["text"] == ""
+        assert call_kwargs["scope"] == ConfigScope.SYSTEM
 
 
 @pytest.mark.unit


### PR DESCRIPTION
`test_stores_text_in_config_manager` and `test_writes_empty_text_on_delete` asserted every `set_config_value` kwarg *except* `scope`. Since `ConfigManager.set_config_value` requires `scope` (no default), a route that dropped it would raise `TypeError` against the real manager — but the `MagicMock` swallows that, so the tests couldn't catch the regression.

Add `assert call_kwargs["scope"] == ConfigScope.SYSTEM` to both. Verified the assertion has teeth: dropping `scope` from the route's `set_instructions` call makes the test fail with `KeyError: 'scope'`.